### PR TITLE
fix a broken link in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 <body>
   <header class="layout-breve">
     <div class="global-header-compact" role="banner">
-      <a href="http://code-for-all.github.io/codeforall.org/" class="global-header-logo">
+      <a href="http://codeforall.org/" class="global-header-logo">
         <img src="images/code_for_all_logo.png" />
       </a>
       <p class="global-header-tagline">An international network of <strong>civic innovators</strong>. </p>


### PR DESCRIPTION
hey @ondrae, I updated the link in the header to go directly to codeforall.org instead of the github.io page

:cake: :cake: :cake: :cake: 
